### PR TITLE
Update pfsense_rule.py with invert rule

### DIFF
--- a/library/pfsense_rule.py
+++ b/library/pfsense_rule.py
@@ -166,21 +166,15 @@ class pfSenseRule(object):
 if (filter_configure() == 0) { clear_subsystem_dirty('rules'); }''')
 
     def parse_address(self, s):
-        # add one more regex for invert rule (maybe better solution!)
-        # TODO find a regex that match all cases
-        invert = None
-        if s.count(':') > 1:
-            m = re.match('([^:]+):?([^:]+):?([^:]+)?', s)
-            invert = m.group(3)
-        else:
-            m = re.match('([^:]+):?([^:]+)?', s)
+        m = re.match('([^:]+):?([^:]+)?', s)
         address = m.group(1)
         port = m.group(2)
-	address = m.group(1)
-        port = m.group(2)
         d = dict()
-        if invert == '!':
+        # Check if the first character is "!"
+        if address[0] == '!':
+            # Invert the rule
             d['not'] = None
+            address = address[1:]
         if address == 'any':
             d['any'] = None
         elif address == 'NET':


### PR DESCRIPTION
This feature allows to invert a rule with "!" .
Exemple:
  - name: "Add invert rule"
    pfsense_rule:
      name: 'Accept all connection except for 192.168.1.100 destination'
      action: pass
      interface: lan
      ipprotocol: inet
      protocol: udp
      source: any
      destination: 192.168.1.100:any:!
      state: present 