### PR TITLE
Rule with interface name (descr)

### DIFF
--- a/module_utils/pfsense/pfsense.py
+++ b/module_utils/pfsense/pfsense.py
@@ -8,7 +8,7 @@ import shutil
 import os
 import pwd
 import time
-import xml.etree.ElementTree as ET 
+import xml.etree.ElementTree as ET
 
 class pfSenseModule(object):
 
@@ -17,6 +17,7 @@ class pfSenseModule(object):
         self.tree = ET.parse('/cf/conf/config.xml')
         self.root = self.tree.getroot()
         self.aliases = self.get_element('aliases')
+        self.interfaces = self.get_element('interfaces')
         self.debug = open('/tmp/pfsense.debug','w')
 
     def get_element(self, node):
@@ -155,6 +156,31 @@ class pfSenseModule(object):
                 return True
         except:
             return False
+        return False
+
+    # return pfsense interface by name
+    def get_interface_pfsense_by_name(self, name):
+        for interface in self.interfaces:
+            interface_name = interface.find('descr').text
+            if interface_name.strip() == name:
+                return interface.tag
+        return None
+
+    # determines if arg is a pfsense interface or not
+    def is_interface_pfsense(self, name):
+        for interface in self.interfaces:
+            interfaceEl = interface.tag.strip()
+            if interfaceEl == name:
+                return True
+        return False
+
+    # determines if arg is an interface name or not
+    def is_interface_name(self, name):
+        for interface in self.interfaces:
+            descrEl = interface.find('descr')
+            if descrEl != None:
+                if descrEl.text.strip() == name:
+                    return True
         return False
 
     def uniqid(self, prefix = ''):


### PR DESCRIPTION
This feature allows to define a rule with interface description.
Exemple:
  - name: "Add NAT rule"
    pfsense_rule:
      name: 'Nat rule with interface description (NAT)'
      action: pass
      interface: NAT
      ipprotocol: inet
      protocol: udp
      source: any
      destination: any:8080
      state: present 