### PR TITLE
pfsense_user: set no_log for password

### DIFF
--- a/library/pfsense_user.py
+++ b/library/pfsense_user.py
@@ -223,7 +223,7 @@ def main():
                 'choices': ['user', 'system']
             },
             'uid': {'type': 'str'},
-            'password': {'type': 'str'},
+            'password': {'type': 'str', 'no_log': True},
             'groupname': {'type': 'str'},
             'priv': {'type': 'list'},
             'authorizedkeys': {'type': 'str'},


### PR DESCRIPTION
Otherwise, ansible warns us with:
> [WARNING]: Module did not set no_log for password