### PR TITLE
[pfsense] Add generic find_elt() function

### DIFF
--- a/library/pfsense_group.py
+++ b/library/pfsense_group.py
@@ -168,31 +168,10 @@ class PFSenseGroupModule(PFSenseModuleBase):
         return self.pfsense.new_element('group')
 
     def _find_target(self):
-        result = self.root_elt.findall("group[name='{0}']".format(self.obj['name']))
-        if len(result) == 1:
-            return result[0]
-        elif len(result) > 1:
-            self.module.fail_json(msg='Found multiple groups for name {0}.'.format(self.obj['name']))
-        else:
-            return None
-
-    def _find_group_by_name(self, name):
-        result = self.root_elt.findall("group[name='{0}']".format(name))
-        if len(result) == 1:
-            return result[0]
-        elif len(result) > 1:
-            self.module.fail_json(msg='Found multiple groups for name {0}.'.format(name))
-        else:
-            return None
+        return self.pfsense.find_elt('group', self.obj['name'], search_field='name', root_elt=self.root_elt)
 
     def _find_group_by_gid(self, gid):
-        result = self.root_elt.findall("group[gid='{0}']".format(gid))
-        if len(result) == 1:
-            return result[0]
-        elif len(result) > 1:
-            self.module.fail_json(msg='Found multiple groups for gid {0}.'.format(gid))
-        else:
-            return None
+        return self.pfsense.find_elt('group', gid, search_field='gid', root_elt=self.root_elt)
 
     def _find_this_group_index(self):
         return self.groups.index(self.target_elt)


### PR DESCRIPTION
@f-bor What do you think about this?  One concern is that one might be tempted to do something like:
```
root_elt = self.pfsense.get_element('blah')
searched_elt = self.pfsense.find_elt(name, root_elt=root_elt)
```
And if there is no 'blah' element, root_elt will be None and find_elt() will search the full tree instead of not searching at all.