### PR TITLE
[pfsense_alias] No longer error on extra parameters with state=absent…

### DIFF
--- a/module_utils/network/pfsense/alias.py
+++ b/module_utils/network/pfsense/alias.py
@@ -28,6 +28,11 @@ ALIAS_REQUIRED_IF = [
 class PFSenseAliasModule(PFSenseModuleBase):
     """ module managing pfsense aliases """
 
+    @staticmethod
+    def get_argument_spec():
+        """ return argument spec """
+        return ALIAS_ARGUMENT_SPEC
+
     ##############################
     # init
     #
@@ -62,12 +67,7 @@ class PFSenseAliasModule(PFSenseModuleBase):
         # check name
         self.pfsense.check_name(params['name'], 'alias')
 
-        # when deleting, only name is allowed
-        if params['state'] == 'absent':
-            for param, value in sorted(params.items()):
-                if param != 'state' and param != 'name' and value is not None:
-                    self.module.fail_json(msg=param + " is invalid with state='absent'")
-        else:
+        if params['state'] == 'present':
             # the GUI does not allow to create 2 aliases with same name and differents types
             alias_elt = self.pfsense.find_alias(params['name'])
             if alias_elt is not None:

--- a/module_utils/network/pfsense/module_base.py
+++ b/module_utils/network/pfsense/module_base.py
@@ -12,6 +12,11 @@ from ansible.module_utils.network.pfsense.pfsense import PFSenseModule
 class PFSenseModuleBase(object):
     """ class providing base services for pfSense modules """
 
+    @staticmethod
+    def get_argument_spec():
+        """ return argument spec """
+        raise NotImplementedError()
+
     ##############################
     # init
     #

--- a/test/units/modules/network/pfsense/pfsense_module.py
+++ b/test/units/modules/network/pfsense/pfsense_module.py
@@ -48,6 +48,7 @@ class TestPFSenseModule(ModuleTestCase):
         self.xml_result = None
         self.tmp_file = None
         self.config_file = None
+        self.pfmodule = None
 
     def setUp(self):
         """ mocking up """
@@ -97,7 +98,10 @@ class TestPFSenseModule(ModuleTestCase):
 
     def get_args_fields(self):
         """ return params fields """
-        raise NotImplementedError()
+        try:
+            return self.pfmodule.get_argument_spec().keys()
+        except AttributeError:
+            raise NotImplementedError()
 
     def get_target_elt(self, obj, absent=False):
         """ return target elt from XML """


### PR DESCRIPTION
….  Implement generic args_from_var() function for tests

@f-bor - I can't find any other ansible module that emits an error when extra parameters are given with state=absent, so I think we should drop that from the alias module.

Also, it seems like we can reasonably implement a generic args_from_var() function by using the argument_spec for the modules.  Thoughts?