### PR TITLE
Fix interface log_update when descr is not known

### DIFF
--- a/module_utils/network/pfsense/interface.py
+++ b/module_utils/network/pfsense/interface.py
@@ -514,6 +514,11 @@ class PFSenseInterfaceModule(PFSenseModuleBase):
 
     def _log_update(self, before):
         """ generate pseudo-CLI command to update an interface """
-        log = "update {0} '{1}'".format(self._get_module_name(True), before['descr'])
+        log = "update {0} '{1}'".format(
+            self._get_module_name(True),
+            # pfSense doesn't enforce a descr on an interface, especially on
+            # first-run so fallback to interface specifier if not known
+            before.get('descr', before['if']),
+        )
         values = self._log_fields(before)
         self.result['commands'].append(log + ' set ' + values)


### PR DESCRIPTION
pfSense does not require that the parameter <descr/> exists and is
populated in the XML, especially after first run. This breaks workflows
which attempt to use Ansible to configure the WAN interface because
lookup of the descr field is absent and execution of the task fails.

In these cases we can fallback to the interface name.