### PR TITLE
fix general settings for 2.5

### DIFF
--- a/library/pfsense_authserver_ldap.py
+++ b/library/pfsense_authserver_ldap.py
@@ -96,29 +96,7 @@ options:
     description: LDAP Group objectClass naming attribute
     default: posixGroup
     type: str
-  ldap_rfc2307:
-    description: LDAP Server uses RFC 2307 style group membership (RFC 2307bis when False)
-    default: false
-    type: bool
-  ldap_rfc2307_userdn:
-    description: Use DN for username search (pfsense-CE >=2.5.0, pfsense-PLUS >=21.2)
-    default: false
-    type: bool
-  ldap_utf8:
-    description: UTF8 encode LDAP parameters before sending them to the server.
-    default: false
-    type: bool
-  ldap_nostrip_at:
-    description: Do not strip away parts of the username after the @ symbol
-    default: false
-    type: bool
-  ldap_pam_groupdn:
-    description: Shell Authentication Group DN (pfsense-CE >=2.5.0, pfsense-PLUS >=21.2)
-    type: str
-  ldap_allow_unathenticated:
-    description: Allow unauthenticated bind (pfsense-CE >=2.5.0, pfsense-PLUS >=21.2)
-    default: false
-    type: bool
+
 """
 
 EXAMPLES = """
@@ -205,17 +183,6 @@ class PFSenseAuthserverLDAPModule(PFSenseModuleBase):
             obj['ldap_attr_group'] = params['attr_group']
             obj['ldap_attr_member'] = params['attr_member']
             obj['ldap_attr_groupobj'] = params['attr_groupobj']
-            if params['ldap_utf8']:
-                obj['ldap_utf8'] = ''
-            if params['ldap_nostrip_at']:
-                obj['ldap_nostrip_at'] = ''
-            if params['ldap_rfc2307']:
-                obj['ldap_rfc2307'] = ''
-
-            if self.pfsense.is_at_least_2_5_0():
-                obj['ldap_pam_groupdn'] = params['ldap_pam_groupdn']
-                if params['ldap_rfc2307_userdn']:
-                    obj['ldap_rfc2307_userdn'] = ''
 
             # Find the caref id for the named CA
             obj['ldap_caref'] = self.pfsense.get_caref(params['ca'])
@@ -245,18 +212,17 @@ class PFSenseAuthserverLDAPModule(PFSenseModuleBase):
         return self.authservers.index(self.target_elt)
 
     def _find_last_index(self):
-        if self.authservers:
-            return list(self.root_elt).index(self.authservers[len(self.authservers) - 1])
-        else:
-            return 0
+        return list(self.root_elt).index(self.authservers[len(self.authservers) - 1])
 
     def _create_target(self):
         """ create the XML target_elt """
-        return self.pfsense.new_element('authserver')
+        return self.pfsense.new_element('user')
 
     def _copy_and_add_target(self):
         """ populate the XML target_elt """
         obj = self.obj
+
+        self.target_elt = self.pfsense.new_element('authserver')
         obj['refid'] = self.pfsense.uniqid()
         self.pfsense.copy_dict_to_element(obj, self.target_elt)
         self.diff['after'] = obj
@@ -315,11 +281,6 @@ def main():
             'attr_group': {'default': 'cn', 'type': 'str'},
             'attr_member': {'default': 'member', 'type': 'str'},
             'attr_groupobj': {'default': 'posixGroup', 'type': 'str'},
-            'ldap_pam_groupdn': {'required': False, 'type': 'str'},
-            'ldap_utf8': {'required': False, 'type': 'bool'},
-            'ldap_nostrip_at': {'required': False, 'type': 'bool'},
-            'ldap_rfc2307': {'required': False, 'type': 'bool'},
-            'ldap_rfc2307_userdn': {'required': False, 'type': 'bool'},
         },
         required_if=[
             ["state", "present", ["host", "port", "transport", "scope", "authcn"]],

--- a/library/pfsense_authserver_ldap.py
+++ b/library/pfsense_authserver_ldap.py
@@ -96,7 +96,29 @@ options:
     description: LDAP Group objectClass naming attribute
     default: posixGroup
     type: str
-
+  ldap_rfc2307:
+    description: LDAP Server uses RFC 2307 style group membership (RFC 2307bis when False)
+    default: false
+    type: bool
+  ldap_rfc2307_userdn:
+    description: Use DN for username search (pfsense-CE >=2.5.0, pfsense-PLUS >=21.2)
+    default: false
+    type: bool
+  ldap_utf8:
+    description: UTF8 encode LDAP parameters before sending them to the server.
+    default: false
+    type: bool
+  ldap_nostrip_at:
+    description: Do not strip away parts of the username after the @ symbol
+    default: false
+    type: bool
+  ldap_pam_groupdn:
+    description: Shell Authentication Group DN (pfsense-CE >=2.5.0, pfsense-PLUS >=21.2)
+    type: str
+  ldap_allow_unathenticated:
+    description: Allow unauthenticated bind (pfsense-CE >=2.5.0, pfsense-PLUS >=21.2)
+    default: false
+    type: bool
 """
 
 EXAMPLES = """
@@ -183,6 +205,17 @@ class PFSenseAuthserverLDAPModule(PFSenseModuleBase):
             obj['ldap_attr_group'] = params['attr_group']
             obj['ldap_attr_member'] = params['attr_member']
             obj['ldap_attr_groupobj'] = params['attr_groupobj']
+            if params['ldap_utf8']:
+                obj['ldap_utf8'] = ''
+            if params['ldap_nostrip_at']:
+                obj['ldap_nostrip_at'] = ''
+            if params['ldap_rfc2307']:
+                obj['ldap_rfc2307'] = ''
+
+            if self.pfsense.is_at_least_2_5_0():
+                obj['ldap_pam_groupdn'] = params['ldap_pam_groupdn']
+                if params['ldap_rfc2307_userdn']:
+                    obj['ldap_rfc2307_userdn'] = ''
 
             # Find the caref id for the named CA
             obj['ldap_caref'] = self.pfsense.get_caref(params['ca'])
@@ -212,17 +245,18 @@ class PFSenseAuthserverLDAPModule(PFSenseModuleBase):
         return self.authservers.index(self.target_elt)
 
     def _find_last_index(self):
-        return list(self.root_elt).index(self.authservers[len(self.authservers) - 1])
+        if self.authservers:
+            return list(self.root_elt).index(self.authservers[len(self.authservers) - 1])
+        else:
+            return 0
 
     def _create_target(self):
         """ create the XML target_elt """
-        return self.pfsense.new_element('user')
+        return self.pfsense.new_element('authserver')
 
     def _copy_and_add_target(self):
         """ populate the XML target_elt """
         obj = self.obj
-
-        self.target_elt = self.pfsense.new_element('authserver')
         obj['refid'] = self.pfsense.uniqid()
         self.pfsense.copy_dict_to_element(obj, self.target_elt)
         self.diff['after'] = obj
@@ -281,6 +315,11 @@ def main():
             'attr_group': {'default': 'cn', 'type': 'str'},
             'attr_member': {'default': 'member', 'type': 'str'},
             'attr_groupobj': {'default': 'posixGroup', 'type': 'str'},
+            'ldap_pam_groupdn': {'required': False, 'type': 'str'},
+            'ldap_utf8': {'required': False, 'type': 'bool'},
+            'ldap_nostrip_at': {'required': False, 'type': 'bool'},
+            'ldap_rfc2307': {'required': False, 'type': 'bool'},
+            'ldap_rfc2307_userdn': {'required': False, 'type': 'bool'},
         },
         required_if=[
             ["state", "present", ["host", "port", "transport", "scope", "authcn"]],

--- a/library/pfsense_setup.py
+++ b/library/pfsense_setup.py
@@ -47,9 +47,17 @@ options:
     required: false
     type: bool
   dnslocalhost:
-    description: Do not use the DNS Forwarder/DNS Resolver as a DNS server for the firewall
     required: false
-    type: bool
+    description: > 
+        Do not use the DNS Forwarder/DNS Resolver as a DNS server for the firewall.
+        "" Use local DNS, fall back to remote DNS server
+        "local" Use local DNS, ignore remote DNS server
+        "remote" Use remote DNS server, ignore local DNS
+        true/yes will be mapped to "remote"
+        false/no will be mapped to ""
+    type: str
+    choices: ["", "local", "remote"]
+    default: ""
   timezone:
     description: Select a geographic region name (Continent/Location) to determine the timezone for the firewall.
     required: false
@@ -76,6 +84,20 @@ options:
     required: false
     choices: ['nohost', 'hostonly', 'fqdn']
     type: str
+  session_timeout:
+    description: Time in minutes to expire idle management sessions (0 means no expiration)
+    required: false
+    default: 240
+    type: int
+  authmode:
+    description: Authentication Server ('Local Database' means local), use name of configured ldap or radius server
+    required: false
+    default: 'Local Database'
+    type: str
+  shellauth:
+    description: Use Authentication Server for Shell Authentication (pfsense-CE >=2.5.0, pfsense-PLUS >=21.2)
+    default: false
+    type: bool
   dashboardcolumns:
     description: Dashboard columns
     required: false
@@ -165,7 +187,13 @@ SETUP_ARGUMENT_SPEC = dict(
     dns_hostnames=dict(required=False, type='str'),
     dns_gateways=dict(required=False, type='str'),
     dnsallowoverride=dict(required=False, type='bool'),
-    dnslocalhost=dict(required=False, type='bool'),
+    dnslocalhost=dict(required=False, type='str', choices=[
+        '',
+        'local',
+        'remote',
+        True,
+        False,
+    ]),
     timezone=dict(required=False, type='str'),
     timeservers=dict(required=False, type='str'),
     language=dict(
@@ -173,6 +201,9 @@ SETUP_ARGUMENT_SPEC = dict(
         type='str',
         choices=['bs', 'de_DE', 'en_US', 'es', 'es_AR', 'fr', 'ko', 'nb', 'nl', 'pl', 'pt_PT', 'pt_BR', 'ru', 'zh_CN', 'zh_Hans_CN', 'zh_HK', 'zh_TW']
     ),
+    session_timeout=dict(required=False, type='int'),
+    authmode=dict(required=False, type='str'),
+    shellauth=dict(required=False, type='bool'),
     webguicss=dict(required=False, type='str'),
     webguifixedmenu=dict(required=False, type='bool'),
     webguihostnamemenu=dict(required=False, type='str', choices=['nohost', 'hostonly', 'fqdn']),
@@ -283,19 +314,40 @@ class PFSenseSetupModule(PFSenseModuleBase):
 
         def _set_param(target, param, strip=False):
             if params.get(param) is not None:
-                if strip:
-                    target[param] = ' '.join(params[param].split())
-                elif isinstance(params[param], str):
-                    target[param] = params[param]
+                if param == 'dnslocalhost':
+                    if str(params.get(param)).lower() in ['', 'false']:
+                        if self.pfsense.is_at_least_2_5_0():
+                            target[param] = ''
+                        else:
+                            del target[param]
+                    elif str(params.get(param)).lower() in ['remote', 'true']:
+                        if self.pfsense.is_at_least_2_5_0():
+                            target[param] = 'remote'
+                        else:
+                            target[param] = ''
+                    elif params.get(param).lower() == 'local':
+                        target[param] = 'local'
+
                 else:
-                    target[param] = str(params[param])
+                    if strip:
+                        target[param] = ' '.join(params[param].split())
+                    elif isinstance(params[param], str):
+                        target[param] = params[param]
+                    else:
+                        target[param] = str(params[param])
 
         def _set_param_bool(target, param):
             if params.get(param) is not None:
-                if params[param] and param not in target:
-                    target[param] = ''
-                elif not params[param] and param in target:
-                    del target[param]
+                if param == 'webguifixedmenu':
+                    if params[param] and (param not in target or target[param] != 'fixed'):
+                        target[param] = 'fixed'
+                    elif not params[param] and param in target:
+                        del target[param]
+                else:
+                    if params[param] and param not in target:
+                        target[param] = ''
+                    elif not params[param] and param in target:
+                        del target[param]
 
         _set_param(obj, 'hostname')
         _set_param(obj, 'domain')
@@ -311,6 +363,10 @@ class PFSenseSetupModule(PFSenseModuleBase):
         _set_param_bool(webgui, 'systemlogsfilterpanel')
         _set_param_bool(webgui, 'systemlogsmanagelogpanel')
         _set_param_bool(webgui, 'statusmonitoringsettingspanel')
+        _set_param(webgui, 'session_timeout')
+        _set_param(webgui, 'authmode')
+        if self.pfsense.is_at_least_2_5_0():
+            _set_param_bool(webgui, 'shellauth')
 
         if params.get('webguicss') is not None:
             webgui['webguicss'] = params['webguicss'] + '.css'
@@ -325,7 +381,7 @@ class PFSenseSetupModule(PFSenseModuleBase):
         _set_param_bool(webgui, 'requirestatefilter')
 
         _set_param_bool(obj, 'dnsallowoverride')
-        _set_param_bool(obj, 'dnslocalhost')
+        _set_param(obj, 'dnslocalhost')
 
         self._dns_params_to_obj(params, obj)
 
@@ -359,6 +415,12 @@ class PFSenseSetupModule(PFSenseModuleBase):
         if params.get('hostname') is not None:
             self._validate_hostname(params['hostname'], 'hostname', True)
 
+        if params.get('dnslocalhost') is not None:
+            if not self.pfsense.is_at_least_2_5_0():
+                value = params.get('dnslocalhost')
+                if not (isinstance(value, bool) or str(value).lower() == '' or str(value).lower() == 'remote'):
+                    self.module.fail_json(msg="unsupported value '{0}' for parameter '{1}'".format(params.get('dnslocalhost'), 'dnslocalhost'))
+
         if params.get('logincss') is not None:
             error = False
             try:
@@ -377,6 +439,22 @@ class PFSenseSetupModule(PFSenseModuleBase):
         if params.get('timeservers') is not None:
             for timeserver in params['timeservers'].split(' '):
                 self._validate_hostname(timeserver, 'timeserver')
+        
+        if params.get('authmode') is not None:
+            value = params.get('authmode')
+            if value != 'Local Database':
+                authserver_elt = self.pfsense.find_elt('authserver', value, search_field='name', root_elt=self.root_elt)
+                if authserver_elt is None:
+                    self.module.fail_json(msg="Given authserver '{0}' could not be found.".format(value))
+                
+                if self.pfsense.is_at_least_2_5_0():
+                    if params.get('shellauth') is not None and params.get('shellauth') is True:
+                        if authserver_elt.find('type').text == 'ldap':
+                            # check if ldap_pam_groupdn is set
+                            if authserver_elt.find('ldap_pam_groupdn') is None or \
+                            authserver_elt.find('ldap_pam_groupdn').text is None or \
+                            authserver_elt.find('ldap_pam_groupdn').text is '':
+                                self.module.fail_json(msg="ldap_pam_groupdn not set for authserver '{0}'.".format(value))
 
         # DNS
         ip_types = []
@@ -438,7 +516,9 @@ class PFSenseSetupModule(PFSenseModuleBase):
     def _remove_deleted_params(self):
         """ Remove from target_elt a few deleted params """
         changed = False
-        params = ['dnsallowoverride', 'dnslocalhost']
+        params = ['dnsallowoverride']
+        if not self.pfsense.is_at_least_2_5_0():
+            params += ['dnslocalhost']
         params += self.params_to_delete
         for param in params:
             if self.pfsense.remove_deleted_param_from_elt(self.target_elt, param, self.obj):
@@ -475,6 +555,7 @@ class PFSenseSetupModule(PFSenseModuleBase):
             self.module.run_command(cmd)
 
         cmd = '''
+require_once("auth.inc");
 require_once("filter.inc");
 $retval = 0;
 $retval |= system_hostname_configure();
@@ -492,6 +573,9 @@ $retval |= system_ntp_configure();'''
             if (self.params['dnsallowoverride'] and 'dnsallowoverride' not in self.before or
                     not self.params['dnsallowoverride'] and 'dnsallowoverride' in self.before):
                 cmd += '$retval |= send_event("service reload dns");\n'
+
+        if self.params.get('shellauth') is not None:
+            cmd += '$retval |= set_pam_auth();'
 
         cmd += '$retval |= filter_configure();\n'
 
@@ -526,7 +610,10 @@ $retval |= system_ntp_configure();'''
         values += self.format_updated_cli_field(self.obj, self.before, 'language', add_comma=(values), log_none=False)
 
         values += self.format_updated_cli_field(self.obj, self.before, 'dnsallowoverride', fvalue=self.fvalue_bool, add_comma=(values), log_none=False)
-        values += self.format_updated_cli_field(self.obj, self.before, 'dnslocalhost', fvalue=self.fvalue_bool, add_comma=(values), log_none=False)
+        if self.pfsense.is_at_least_2_5_0:
+            values += self.format_updated_cli_field(self.obj, self.before, 'dnslocalhost', add_comma=(values), log_none=False)
+        else:
+            values += self.format_updated_cli_field(self.obj, self.before, 'dnslocalhost', fvalue=self.fvalue_bool, add_comma=(values), log_none=False)
 
         values += self.format_updated_cli_field(obj_after, obj_before, 'webguicss', add_comma=(values), log_none=False)
         values += self.format_updated_cli_field(webgui, bwebgui, 'webguifixedmenu', fvalue=self.fvalue_bool, add_comma=(values), log_none=False)

--- a/library/pfsense_setup.py
+++ b/library/pfsense_setup.py
@@ -56,7 +56,7 @@ options:
         true/yes will be mapped to "remote"
         false/no will be mapped to ""
     type: str
-    choices: ["", "local", "remote"]
+    choices: ["", "local", "remote", True, False]
     default: ""
   timezone:
     description: Select a geographic region name (Continent/Location) to determine the timezone for the firewall.
@@ -201,8 +201,8 @@ SETUP_ARGUMENT_SPEC = dict(
         type='str',
         choices=['bs', 'de_DE', 'en_US', 'es', 'es_AR', 'fr', 'ko', 'nb', 'nl', 'pl', 'pt_PT', 'pt_BR', 'ru', 'zh_CN', 'zh_Hans_CN', 'zh_HK', 'zh_TW']
     ),
-    session_timeout=dict(required=False, type='int'),
-    authmode=dict(required=False, type='str'),
+    session_timeout=dict(required=False, type='int', default=240),
+    authmode=dict(required=False, type='str', default='Local Database'),
     shellauth=dict(required=False, type='bool'),
     webguicss=dict(required=False, type='str'),
     webguifixedmenu=dict(required=False, type='bool'),

--- a/library/pfsense_setup.py
+++ b/library/pfsense_setup.py
@@ -453,7 +453,7 @@ class PFSenseSetupModule(PFSenseModuleBase):
                             # check if ldap_pam_groupdn is set
                             if authserver_elt.find('ldap_pam_groupdn') is None or \
                                authserver_elt.find('ldap_pam_groupdn').text is None or \
-                               authserver_elt.find('ldap_pam_groupdn').text is '':
+                               authserver_elt.find('ldap_pam_groupdn').text == '':
                                 self.module.fail_json(msg="ldap_pam_groupdn not set for authserver '{0}'.".format(value))
 
         # DNS

--- a/library/pfsense_setup.py
+++ b/library/pfsense_setup.py
@@ -48,7 +48,7 @@ options:
     type: bool
   dnslocalhost:
     required: false
-    description: > 
+    description: >
         Do not use the DNS Forwarder/DNS Resolver as a DNS server for the firewall.
         "" Use local DNS, fall back to remote DNS server
         "local" Use local DNS, ignore remote DNS server
@@ -439,22 +439,22 @@ class PFSenseSetupModule(PFSenseModuleBase):
         if params.get('timeservers') is not None:
             for timeserver in params['timeservers'].split(' '):
                 self._validate_hostname(timeserver, 'timeserver')
-        
+
         if params.get('authmode') is not None:
             value = params.get('authmode')
             if value != 'Local Database':
                 authserver_elt = self.pfsense.find_elt('authserver', value, search_field='name', root_elt=self.root_elt)
                 if authserver_elt is None:
                     self.module.fail_json(msg="Given authserver '{0}' could not be found.".format(value))
-                
+
                 if self.pfsense.is_at_least_2_5_0():
                     if params.get('shellauth') is not None and params.get('shellauth') is True:
                         if authserver_elt.find('type').text == 'ldap':
                             # check if ldap_pam_groupdn is set
                             if authserver_elt.find('ldap_pam_groupdn') is None or \
-                            authserver_elt.find('ldap_pam_groupdn').text is None or \
-                            authserver_elt.find('ldap_pam_groupdn').text is '':
-                                self.module.fail_json(msg="ldap_pam_groupdn not set for authserver '{0}'.".format(value))
+                                authserver_elt.find('ldap_pam_groupdn').text is None or \
+                                authserver_elt.find('ldap_pam_groupdn').text is '':
+                                    self.module.fail_json(msg="ldap_pam_groupdn not set for authserver '{0}'.".format(value))
 
         # DNS
         ip_types = []

--- a/library/pfsense_setup.py
+++ b/library/pfsense_setup.py
@@ -452,9 +452,9 @@ class PFSenseSetupModule(PFSenseModuleBase):
                         if authserver_elt.find('type').text == 'ldap':
                             # check if ldap_pam_groupdn is set
                             if authserver_elt.find('ldap_pam_groupdn') is None or \
-                                authserver_elt.find('ldap_pam_groupdn').text is None or \
-                                authserver_elt.find('ldap_pam_groupdn').text is '':
-                                    self.module.fail_json(msg="ldap_pam_groupdn not set for authserver '{0}'.".format(value))
+                               authserver_elt.find('ldap_pam_groupdn').text is None or \
+                               authserver_elt.find('ldap_pam_groupdn').text is '':
+                                self.module.fail_json(msg="ldap_pam_groupdn not set for authserver '{0}'.".format(value))
 
         # DNS
         ip_types = []


### PR DESCRIPTION
Extended pfsense_setup:
 - dnslocalhost (bool for <2.5.0 and str >=2.5.0), mapping true/false to
 'remote' and '' on newer systems, mapping ''/'remote' to false/true on
 older systems
 - shellauth: use shell authentication
 - authmode: select ldap or radius server used for authentication
 - session_timeout: was simply missing